### PR TITLE
Yarm support for mongodb 2.x, mongoose 4.xx

### DIFF
--- a/lib/httpStatus.js
+++ b/lib/httpStatus.js
@@ -5,6 +5,7 @@ var data = {
 	created: { code: 201, body: "Created" },
 	noContent: { code: 204, body: "" },
 	badRequest: { code: 400, body: "Bad request" },
+  unauthorized: {code: 401, body: "Unauthorized"},
 	notFound: { code: 404, body: "Not found" },
 	methodNotAllowed: { code: 405, body: "Method not allowed" },
 	notImplemented: { code: 501, body: "Not implemented"}

--- a/lib/mongoose/aggregate.js
+++ b/lib/mongoose/aggregate.js
@@ -4,7 +4,7 @@
 var queryHelpers = require("./query"),
 
 	mongodb = require("mongodb"),
-	ObjectId = mongodb.BSONPure.ObjectID;
+	ObjectId = mongodb.ObjectID;
 
 
 /*!

--- a/lib/yarm.js
+++ b/lib/yarm.js
@@ -47,6 +47,8 @@ function instanciate() {
 				handler(req, res);
 			};
 
+
+
 			httpStatus.names.forEach(function(name) {
 				cb[name] = function() {
 					handleError(req, res, httpStatus[name]());
@@ -172,6 +174,9 @@ function instanciate() {
 					}
 
 					var hook = data.hooks.shift();
+          nextHook.status = function(code, body) {
+            handleError(req, res, httpStatus(code, body));
+          };
 
 					if (hook) {
 						try {
@@ -184,6 +189,8 @@ function instanciate() {
 					}
 				});
 			}
+
+
 
 			httpStatus.names.forEach(function(name) {
 				nextHook[name] = function() {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "main": "index.js",
   "devDependencies": {
     "mocha": "*",
-    "express": "~3.5.1",
+    "express": "~4.3.1",
     "mongoose": "*",
     "mongodb": "*"
   },


### PR DESCRIPTION
Note this request also includes httpStatus definition. unauthorized: {code: 401, body: "Unauthorized"} and support for middleware returning a dynamic status(even if not defined in httpStatus).  e.g. next.status(401, 'This is unauthorized')