### PR TITLE
set PUT method to replace whole document

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -776,7 +776,7 @@ HTTP/1.1 404 Not found
 
 #### PUT and PATCH: updating documents
 
-Clients can update documents by sending PUT or PATCH requests on the document URL.  For now, both methods behave as a PATCH request, that is, they update all fields that are present in the request body, without touching other fields.
+Clients can update documents by sending PUT or PATCH requests on the document URL.  PATCH requests update all fields that are present in the request body, without touching other fields.  PUT requests update all fields of the document, setting to undefined those absent of the request body.
 
 ```
 $ curl -X PATCH -d '{"title":"New title"}' \
@@ -786,6 +786,14 @@ $ curl http://localhost/rest/posts/507f191e810c19729de860ea
   "_id": "507f191e810c19729de860ea",
   "title": "New title",
   "text": "Hello, World"
+}
+
+$ curl -X PUT -H "Content-Type: application/json" -d '{"title":"New title"}' \
+  http://localhost/rest/posts/507f191e810c19729de860ea
+$ curl http://localhost/rest/posts/507f191e810c19729de860ea
+{
+  "_id": "507f191e810c19729de860ea",
+  "title": "New title"
 }
 ```
 

--- a/lib/mongoose/model.js
+++ b/lib/mongoose/model.js
@@ -140,7 +140,16 @@ function mongooseDocPut(req, isPatch, cb) {
 		return cb.notFound();
 	}
 
-	doc.set(req.body);
+	if (isPatch) {
+		doc.set(req.body);
+	} else {
+		req.mongoose.doc.schema.eachPath(function(path) {
+			if (path !== '_id' && path !== '__v') {
+				doc.set(path, req.body[path]);
+			}
+		});
+	}
+
 	doc.save(function(err) {
 		cb(err);
 	});

--- a/test/mongoose.js
+++ b/test/mongoose.js
@@ -538,10 +538,26 @@ describe("Mongoose resources", function() {
 			});
 
 			it("should PUT documents", function(done) {
+				var item = testData[1];
+				mongooseResource("test", TestModel);
+
+				request.put("/test/" + item._id, testData[0], function(res, body) {
+					assertEmpty(body);
+					assert.strictEqual(res.statusCode, 204);
+
+					TestModel.findById(item._id, function(err, doc) {
+						assert.ifError(err);
+						assert.strictEqual(doc.field2, undefined);
+						done();
+					});
+				});
+			});
+
+			it("should PATCH documents", function(done) {
 				var item = testData[0];
 				mongooseResource("test", TestModel);
 
-				request.put("/test/" + item._id, { field2: "bar" }, function(res, body) {
+				request.patch("/test/" + item._id, { field2: "bar" }, function(res, body) {
 					assertEmpty(body);
 					assert.strictEqual(res.statusCode, 204);
 


### PR DESCRIPTION
Make PUT requests replace all fields of document and set empty fields of the request body to undefined. 